### PR TITLE
Update cScanner.l

### DIFF
--- a/cScanner.l
+++ b/cScanner.l
@@ -1,55 +1,79 @@
 %{
 #include"./cCompilerCommon.h"
+#include "./y.tab.h"
+#include <stdio.h>
+void echo();
+void errecho();
 %}
 
 intNumber [0-9][0-9]*
 identifier [a-zA-Z_][a-zA-Z0-9_]*
 doubleNumber {intNumber}.{intNumber}
 emptyChar [ \t\n]
-char \'.\'
+char \'.\'|\'\\.\'
 string \"[^\"]*\"
 
-%%
-{emptyChar} {;}
-
-int {return INT;}
-double {return DOUBLE;}
-char {return CHAR;}
-for {return FOR;}
-do {return DO;}
-while {return WHILE;}
-continue {return CONTINUE;}
-break {return BREAK;}
-switch {return SWITCH;}
-case {return CASE;}
-default {return DEFAULT;}
-if {return IF;}
-else {return ELSE;}
-return {return RETURN;}
-struct {return STRUCT;}
-unsigned {return UNSIGNED;}
-const {return CONST;}
-static {return STATIC;}
-
-
-
-{intNumber} {return NUMBER;}
-{doubleNumber} {return NUMBER;}
-\+\= {return ADD_ASSIGN;}
-\-\= {return SUB_ASSIGN;}
-\*\= {return MUL_ASSIGN;}
-\/\= {return DIV_ASSIGN;}
-\&\& {return LOGICAL_AND;}
-\|\| {return LOGICAL_OR;}
-\=\= {return EQ;}
-\!\= {return NE;}
-\<\< {return SL;}
-\>\> {return SR;}
-\+\+ {return INC;}
-\-\- {return DEC;}
-\-\> {return PTR;}
-
-{identifier} {return IDENTIFIER;}
-{string} {return STRING;}
+commitLine \/\/.*\n
 
 %%
+{emptyChar} {printf("emptyChar\n");}
+{commitLine} {printf("commit: \"%s\"\n",yytext);}
+
+int {echo();return INT;}
+float {echo();return FLOAT;}
+double {echo();return DOUBLE;}
+char {echo();return CHAR;}
+for {echo();return FOR;}
+do {echo();return DO;}
+while {echo();return WHILE;}
+continue {echo();return CONTINUE;}
+break {echo();return BREAK;}
+switch {echo();return SWITCH;}
+case {echo();return CASE;}
+default {echo();return DEFAULT;}
+if {echo();return IF;}
+else {echo();return ELSE;}
+return {echo();return RETURN;}
+struct {echo();return STRUCT;}
+unsigned {echo();return UNSIGNED;}
+const {echo();return CONST;}
+static {echo();return STATIC;}
+void {echo();return VOID;}
+
+
+
+{intNumber} {echo();return NUMBER;}
+{doubleNumber} {echo();return NUMBER;}
+{char} {echo();return NUMBER;}
+\+\= {echo();return ADD_ASSIGN;}
+\-\= {echo();return SUB_ASSIGN;}
+\*\= {echo();return MUL_ASSIGN;}
+\/\= {echo();return DIV_ASSIGN;}
+\&\& {echo();return LOGICAL_AND;}
+\|\| {echo();return LOGICAL_OR;}
+\=\= {echo();return EQ;}
+\!\= {echo();return NE;}
+\<\= {echo();return LE;}
+\>\= {echo();return GE;}
+\<\< {echo();return SL;}
+\>\> {echo();return SR;}
+\+\+ {echo();return INC;}
+\-\- {echo();return DEC;}
+\-\> {echo();return PTR;}
+
+
+{identifier} {echo();return IDENTIFIER;}
+{string} {echo();return STRING;}
+. {
+    errecho();
+    return yytext[0];
+}
+
+%%
+
+void echo(){
+    printf("get: %s\n",yytext);
+}
+void errecho(){
+    printf("undefined: %s\n",yytext);
+}


### PR DESCRIPTION
稍微加了点调试用的语句。
修正了 char 的识别，现在它可以正确匹配诸如 '\n' 、 '\t' 这样的转义了。
简单地加了一个单行注释，现在它可以正确匹配以 “//” 开头、以换行结尾的单行注释了。
添加了 const、static、void 等关键字，添加了箭头算符（->）、大于等于和小于等于
修正了未匹配到的字符的默认行为。现在它可以正常将诸如 '{' 、'*' 、'+' 这样的单个为匹配到的字符原样返回了。